### PR TITLE
Scaffold MkDocs Material docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ __pycache__/
 *.py[oc]
 *.egg-info/
 .venv/
+
+# MkDocs
+/site/
+.venv-docs/

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,29 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
+##@ Documentation
+
+DOCS_VENV ?= .venv-docs
+DOCS_PY ?= $(DOCS_VENV)/bin/python
+DOCS_PIP ?= $(DOCS_VENV)/bin/pip
+MKDOCS ?= $(DOCS_VENV)/bin/mkdocs
+
+$(DOCS_VENV)/.stamp: requirements-docs.txt
+	python3 -m venv $(DOCS_VENV)
+	$(DOCS_PIP) install -r requirements-docs.txt
+	touch $(DOCS_VENV)/.stamp
+
+.PHONY: docs-venv
+docs-venv: $(DOCS_VENV)/.stamp ## Create .venv-docs and install docs dependencies.
+
+.PHONY: docs-serve
+docs-serve: docs-venv ## Serve docs locally at http://127.0.0.1:8000 with live reload.
+	$(MKDOCS) serve
+
+.PHONY: docs-build
+docs-build: docs-venv ## Build static docs site to ./site/ (strict mode).
+	$(MKDOCS) build --strict
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+token-rotator.com

--- a/docs/design/aggregation.md
+++ b/docs/design/aggregation.md
@@ -1,0 +1,14 @@
+# Aggregation
+
+Every CRD registers into shared categories so all token types can be listed
+together:
+
+- `kubectl get tokens` — every rotated token in the cluster, across sources.
+- `kubectl get gitlab` — every GitLab-sourced token.
+
+All token CRDs expose the same baseline printer columns — `Ready`, `Last
+Rotated`, `Next Rotation`, `Export`, `Age` — so the aggregated view is usable
+without `-o wide`.
+
+Source-specific columns (e.g. GitLab `access_level`) are registered at
+`priority: 1` and only appear with `-o wide`.

--- a/docs/design/crd-per-source.md
+++ b/docs/design/crd-per-source.md
@@ -1,0 +1,19 @@
+# One CRD per token source
+
+Rather than a single generic `Token` CRD with an opaque `config` field, each
+token source gets its own strongly-typed CRD. The APIs for minting tokens vary
+too much between providers — GitLab takes a flat `scopes[]` + integer
+`access_level`, Tailscale takes a nested `capabilities` object with tags,
+DataDog API keys have no scopes at all, ArgoCD tokens defer permissions to
+out-of-band RBAC, etc. — for a single schema to be useful.
+
+Per-source CRDs give us:
+
+- **`kubectl apply`-time validation** via OpenAPI schema per source.
+- **Per-source RBAC** — grant minting rights for GitLab tokens without
+  granting anything on Tailscale keys.
+- **Independent versioning** — a source can move from `v1alpha1` to `v1beta1`
+  without dragging the others.
+
+A generic `CustomToken` escape-hatch CRD may be added later but is not the
+default.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,0 +1,14 @@
+# Design
+
+The architectural decisions behind Token Rotator. Each page covers one
+pillar.
+
+- **[One CRD per source](crd-per-source.md)** — why we rejected a single
+  generic `Token` CRD.
+- **[Naming](naming.md)** — API group and kind conventions.
+- **[Aggregation](aggregation.md)** — shared categories and printer columns.
+- **[Shared spec and status](shared-spec.md)** — common fields embedded in
+  every source CRD.
+- **[Resolutions to open questions](open-questions-resolutions.md)** —
+  decisions on failure handling, rotation strategy, export targets, and
+  credential management.

--- a/docs/design/naming.md
+++ b/docs/design/naming.md
@@ -1,0 +1,9 @@
+# Naming
+
+All CRDs live in a single API group: **`token-rotator.org`**. Kinds are
+prefixed with the source name to keep them unambiguous (e.g.
+`GitLabProjectAccessToken`, `TailscaleAuthKey`). This follows the
+cert-manager / external-secrets / ArgoCD convention.
+
+If the project ever grows to Crossplane scale (dozens of kinds per source) the
+trade-off to per-source API subgroups could be revisited — but we're not close.

--- a/docs/design/open-questions-resolutions.md
+++ b/docs/design/open-questions-resolutions.md
@@ -1,0 +1,201 @@
+# Resolutions to README Open Design Questions
+
+Working plan for the four open questions in `README.md`. Each section captures
+the decision, rationale, and the concrete work implied.
+
+---
+
+## 1. Failure handling: observability surface
+
+**Decision:** Emit Kubernetes Events for rotation lifecycle, plus metrics via the
+OpenTelemetry SDK configured to export to both Prometheus (scrape endpoint) and
+OTLP (push).
+
+**Rationale:**
+- Kubernetes Events are idiomatic, cheap, and the integration point every
+  downstream tool (event-exporter, Argo Events, Argo Notifications,
+  Alertmanager) already consumes. Covers "someone should know."
+- Prometheus is where the kubebuilder / operator ecosystem lives; every peer
+  project (cert-manager, ESO, ArgoCD, Flux) uses it. Users' dashboards and
+  Alertmanager rules transfer with no effort.
+- OTel API in code lets the same instrumentation also push OTLP for users on
+  OTel-native stacks, and leaves the door open for traces later without a
+  second instrumentation system. Cost is extra `main.go` plumbing; benefit is
+  not having to migrate later.
+- Labels/attributes only carry names and reasons — never token values — so this
+  conforms to the existing "never log `minted.Value`" posture.
+
+**Scope of work:**
+- Wire the OTel SDK in `cmd/main.go`. Prometheus exporter mounted on the
+  existing controller-runtime metrics server; OTLP exporter configurable via
+  env vars (off by default).
+- Instruments:
+  - `token_rotator_rotation_attempts_total{kind,source,namespace,name,result}`
+    (counter; `result` ∈ `success|failure`).
+  - `token_rotator_rotation_failures_total{kind,source,namespace,name,reason}`
+    (counter; derived/convenience).
+  - `token_rotator_last_success_timestamp_seconds{...}` (async gauge; callback
+    reads informer cache).
+  - `token_rotator_token_expiry_timestamp_seconds{...}` (async gauge).
+- Cardinality: per-CR labels (`namespace`, `name`). Matches cert-manager.
+- Event reasons (emit via `record.EventRecorder`):
+  `RotationStarted`, `RotationSucceeded`, `RotationFailed`,
+  `TokenRevoked`, `ExportUpdated`, `TookOwnership`,
+  `DependencyCycle`, `SecretNotAdopted`, `InvalidGracePeriod`.
+- Status conditions continue to surface `Ready` with reason/message as today.
+
+**Explicitly not doing:** bespoke webhook notifications from the operator,
+Argo Notifications-style annotation templates on the CR.
+
+---
+
+## 2. `KeepOld` grace period
+
+**Decision:** Fixed-duration grace period on the CR. Default `1h`. Ceiling is
+`min(7d, rotationInterval - ε)` — the `< rotationInterval` constraint
+guarantees at most one extra token exists at any moment.
+
+**Schema:**
+```yaml
+spec:
+  rotationStrategy:
+    type: KeepOld
+    keepOld:
+      gracePeriod: 1h
+```
+
+**Controller behavior:**
+- On successful mint + export, record `status.previousTokenRef` and
+  `status.previousTokenRevocationTime = now + gracePeriod`. Requeue at that
+  time.
+- On reconcile after the deadline, call the source's revoke API (idempotent —
+  treat 404 as success) and clear `previousTokenRef`.
+- Validate `gracePeriod < rotationInterval` at reconcile; on violation set
+  `Ready=False, reason=InvalidGracePeriod`. (Can't express dynamically in CRD
+  OpenAPI validation.)
+- Hard cap enforced via CRD validation: `gracePeriod <= 7d`.
+- Crash recovery: status persists the revocation deadline, so a restarted
+  controller resumes correctly.
+
+**Edge cases:**
+- **Rotation N+1 fails while the previous token's grace window is still open:**
+  keep the previous-token revocation on its original schedule. Don't extend
+  (the previous one might be the leaked credential).
+- **New token minted but export fails:** revoke the newly-minted token
+  immediately on detection — don't leak a third credential into the wild.
+
+**Status surface:**
+- `status.previousTokenRef` and `status.previousTokenRevocationTime`.
+- Printer column showing the grace-window countdown so the two-token state is
+  visible in `kubectl get`.
+
+**User guidance in docs:** pair with Reloader (in-cluster) or ESO's
+refresh-interval tuning (external) if pods/consumers are slow to pick up the
+new Secret. The operator's contract ends at "Secret contains current value."
+
+---
+
+## 3. Export targets
+
+**Decision:** `Secret` only. Keep the existing single `export` block — do not
+migrate to `exports[]` until a second target is actually needed.
+
+**Rationale:**
+- ESO's `PushSecret` is a standalone resource that references any Secret via
+  `spec.selector.secret.name`. Users compose it on top of our Secret output
+  without any integration work from us.
+- ESO's Webhook provider (SecretStore with `provider: webhook`) handles
+  webhook delivery end-to-end: URL, auth, body templating, retries. Better at
+  webhooks than we would ever be, with none of the security surface.
+- YAGNI on `exports[]`: v1alpha1 allows breaking changes, so we can migrate
+  when a real second target appears.
+
+**Composition patterns to document** (new README section):
+- **In-cluster consumers:** [Reloader](https://github.com/stakater/Reloader)
+  restarts Deployments when the Secret changes.
+- **Push to external secret stores** (Vault, AWS SM, GCP SM, Doppler, …):
+  create an ESO `PushSecret` referencing our output Secret.
+- **Webhook delivery:** ESO `SecretStore` with `provider: webhook` + a
+  `PushSecret`. Example YAML in the docs.
+- **Cross-tool notification fan-out:** `kubernetes-event-exporter` /
+  Argo Events / Alertmanager, consuming the Events and metrics from §1.
+
+**Explicitly not doing:** native webhook field on the CR, direct cloud
+secret-manager writes, ConfigMap export, file/log export.
+
+---
+
+## 4. Operator credential management: self-referential CRDs
+
+**Decision:** Support source-specific self-rotate CRDs where the source API
+allows it (starting with `GitLabPersonalAccessToken`). For sources without
+self-rotate, the root credential stays user-managed.
+
+The existing `apiTokenSecretRef` field is already flexible enough to enable
+composition (one CR's output Secret is another CR's API-credential input) —
+no new schema required for that case.
+
+### Self-rotate CRD behavior
+
+- New CRD per source: e.g. `GitLabPersonalAccessToken`. Exports to the Secret
+  that other CRs reference via `apiTokenSecretRef`.
+- First reconcile: adopt the user-created Secret (ownership transfer), call
+  the source's self-rotate endpoint, write the new value back.
+- Subsequent reconciles: scheduled rotation via the same endpoint.
+- Adoption is gated on explicit opt-in: `spec.adoptExistingSecret: true`. If
+  unset and the Secret exists, `Ready=False, reason=SecretNotAdopted`.
+- On first adoption, emit Event
+  `TookOwnership secret=<name>; future rotations will mutate /data/<key> in
+  place; ensure your bootstrap tool does not revert this field`.
+
+### Cycle detection (for the composition pattern)
+
+- On reconcile, walk owner-refs from `apiTokenSecretRef` to detect cycles
+  among operator-managed Secrets. Bound the walk.
+- On cycle: `Ready=False, reason=DependencyCycle` on all CRs in the cycle.
+  Don't silently break it.
+- Ordering between dependent CRs: rely on natural requeue-on-error
+  (NotFound → requeue → retry after dependency mints). No DAG scheduler
+  needed.
+
+### Bootstrap paths (documented, not code)
+
+The initial credential value has to come from somewhere. Three supported
+paths:
+
+1. **Manual `kubectl create secret`** — lowest friction.
+2. **GitOps (SealedSecret / SOPS + ArgoCD/Flux)** — encrypted in git, decrypted
+   into a Secret. Requires `ignoreDifferences` on `/data/<key>` in the ArgoCD
+   Application (or equivalent) so the sync controller doesn't revert rotated
+   values. Example in docs.
+3. **ESO `ExternalSecret` with `refreshInterval: 0`** — credential lives in a
+   vault, ESO materializes it once, operator takes over. Cleanest separation;
+   requires ESO + a vault.
+
+**Key invariant to call out in docs:** the operator writes `/data/<keyName>`;
+whatever produces the bootstrap value must not fight the operator over that
+field after adoption.
+
+### Explicitly not doing
+
+- Dedicated `Provider` / `TokenProvider` CRD (ESO-style). Deferred per
+  CLAUDE.md; still true.
+- OIDC / workload-identity federation for source APIs. Most sources we target
+  don't support it at the required scopes.
+
+---
+
+## Implementation order (rough)
+
+1. **OTel + Prometheus metrics + Events** (§1). Self-contained, unlocks
+   observability for everything else. Extends existing reconciler.
+2. **`KeepOld` grace period** (§2). Requires status additions, revoke API
+   surface in `internal/sources/gitlab`, reconcile-time validation.
+3. **Documentation pass** (§3 and §4 composition patterns). Docs-only; no
+   code.
+4. **`GitLabPersonalAccessToken` CRD** (§4). New CRD kind; reuses shared
+   `TokenSpecBase`. First use of adoption + self-rotate patterns. Needs cycle
+   detection in the shared reconcile path.
+
+README's "Open design questions" section gets replaced with a short pointer
+to this doc once implementations land.

--- a/docs/design/shared-spec.md
+++ b/docs/design/shared-spec.md
@@ -1,0 +1,35 @@
+# Shared spec and status
+
+All token CRDs embed a common base spec and status; per-source specs add their
+own fields on top.
+
+```yaml
+spec:
+  rotationSchedule: "0 0 1 * *"    # cron
+  forceNow: false
+  rotationStrategy: Immediate       # Immediate | KeepOld
+  apiTokenSecretRef:                # the credential the controller uses to mint
+    name: gitlab-api-credentials
+    key: token
+  export:
+    type: Secret
+    name: gitlab-ci-token
+    namespace: default
+  # source-specific fields:
+  project: mygroup/myproject
+  accessLevel: Maintainer
+  scopes: [api, read_registry]
+
+status:
+  conditions: [...]
+  lastRotationTime: ...
+  nextRotationTime: ...
+  currentTokenRef: {name: ..., namespace: ...}
+```
+
+The shared types live in `api/v1alpha1/tokenbase_types.go`. Shared behavior
+(schedule parsing, condition helpers, export) lives in
+`internal/rotation/`.
+
+No `TokenSource` interface: the specs vary too much to abstract usefully. Each
+per-source reconciler calls its concrete client directly.

--- a/docs/getting-started/deploy.md
+++ b/docs/getting-started/deploy.md
@@ -1,0 +1,13 @@
+# Deploy
+
+Build and push the image, then deploy the manager:
+
+```sh
+make docker-build docker-push IMG=ghcr.io/devonwarren/token-rotator:dev
+make deploy IMG=ghcr.io/devonwarren/token-rotator:dev
+```
+
+The manager Deployment is configured with a hardened security context
+(`runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`,
+all capabilities dropped, `seccompProfile: RuntimeDefault`). See
+`config/manager/manager.yaml`.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,19 @@
+# Getting Started
+
+Install the operator, apply a sample custom resource, and watch it mint a token.
+
+## Prerequisites
+
+- Go 1.25+
+- Docker (or another OCI builder — set `CONTAINER_TOOL` in the Makefile)
+- `kubectl` pointed at a Kubernetes cluster
+- [kubebuilder](https://book.kubebuilder.io/) (only needed for regenerating
+  scaffolded code)
+
+## Walkthrough
+
+1. **[Install](install.md)** — `make install` / `make run` against a cluster.
+2. **[Deploy](deploy.md)** — build and push the manager image, `make deploy`.
+3. **[Try it](try-it.md)** — create an API-credential Secret, apply a sample
+   CR, observe rotation.
+4. **[Tear down](tear-down.md)** — remove the CR, uninstall the operator.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,17 @@
+# Install
+
+Install the CRDs into the currently-configured cluster:
+
+```sh
+make install
+```
+
+Run the controller against that cluster from your workstation (outside the
+cluster, using your kubeconfig):
+
+```sh
+make run
+```
+
+This is the quickest path for local iteration. To deploy the controller *into*
+the cluster, see [Deploy](deploy.md).

--- a/docs/getting-started/tear-down.md
+++ b/docs/getting-started/tear-down.md
@@ -1,0 +1,10 @@
+# Tear down
+
+```sh
+kubectl delete -k config/samples/
+make undeploy
+make uninstall
+```
+
+`make undeploy` removes the manager; `make uninstall` removes the CRDs. Order
+matters — deleting CRDs first would strand finalizers.

--- a/docs/getting-started/try-it.md
+++ b/docs/getting-started/try-it.md
@@ -1,0 +1,19 @@
+# Try it
+
+Create a Secret holding the GitLab API token the operator will use to mint
+project access tokens, then apply the sample CR:
+
+```sh
+kubectl create secret generic gitlab-api-credentials \
+  --from-literal=token=<your-gitlab-pat>
+
+kubectl apply -k config/samples/
+
+kubectl get tokens
+```
+
+`kubectl get tokens` aggregates across every token source — see
+[Design › Aggregation](../design/aggregation.md).
+
+For per-source details, see
+[Sources › GitLab project access token](../sources/gitlab-project-access-token.md).

--- a/docs/guides/argocd-integration.md
+++ b/docs/guides/argocd-integration.md
@@ -1,0 +1,45 @@
+# ArgoCD integration
+
+If you deploy rotated Secrets from git via ArgoCD, auto-sync will fight the
+operator: it reverts the rotated value back to what's in git. Tell ArgoCD to
+ignore the specific data key the operator writes.
+
+## `ignoreDifferences`
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source: { ... }
+  destination: { ... }
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: gitlab-api-credentials
+      jsonPointers:
+        - /data/token
+```
+
+With this in place, ArgoCD still creates the Secret from your git manifest on
+first sync, and the operator takes ownership of `/data/token` on first
+reconcile. Subsequent rotations don't register as drift.
+
+## When to use which
+
+- **ArgoCD-managed Secret, operator rotates in place:** use
+  `ignoreDifferences` as above.
+- **ESO-managed Secret:** set `refreshInterval: "0"` on the `ExternalSecret`
+  so ESO doesn't refresh a field the operator now owns.
+- **Manual `kubectl create secret`:** nothing to do.
+
+## Adoption signal
+
+On first adoption, the operator emits an Event:
+
+> `TookOwnership secret=gitlab-api-credentials; future rotations will mutate /data/token in place; ensure your bootstrap tool does not revert this field`
+
+Watch for it with `kubectl get events --field-selector reason=TookOwnership`.

--- a/docs/guides/bootstrap-credentials.md
+++ b/docs/guides/bootstrap-credentials.md
@@ -1,0 +1,72 @@
+# Bootstrap credentials
+
+The operator needs an API credential to mint tokens. That credential has to
+exist in the cluster before the first reconcile — you can't materialize a
+credential from nothing.
+
+After bootstrap, the operator can manage its own credential rotation for
+sources that support self-rotate (e.g. GitLab PATs). This page walks through
+each bootstrap option.
+
+## Three paths
+
+=== "Manual"
+
+    Lowest friction; fine for single-cluster or evaluation setups.
+
+    ```sh
+    kubectl create secret generic gitlab-api-credentials \
+      --from-literal=token=<your-gitlab-pat>
+    ```
+
+    Reference the Secret from your CR's `spec.apiTokenSecretRef`.
+
+=== "GitOps (SealedSecret / SOPS)"
+
+    Encrypt the credential in git, let ArgoCD/Flux decrypt it into a
+    Secret. See [ArgoCD integration](argocd-integration.md) for the
+    `ignoreDifferences` pattern you need once the operator starts rotating
+    the value.
+
+=== "ESO (External Secrets Operator)"
+
+    Keeps the bootstrap credential out of the cluster entirely. Credential
+    lives in a vault (Vault, AWS Secrets Manager, Doppler, …); ESO
+    materializes it once and the operator takes over.
+
+    ```yaml
+    apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: gitlab-api-credentials
+    spec:
+      refreshInterval: "0"      # fetch once, then never again
+      secretStoreRef:
+        name: vault
+        kind: ClusterSecretStore
+      target:
+        name: gitlab-api-credentials
+        creationPolicy: Owner
+      data:
+        - secretKey: token
+          remoteRef:
+            key: secret/gitlab
+            property: bootstrap-pat
+    ```
+
+## Self-rotating the bootstrap credential (planned)
+
+For sources that support it, a dedicated CRD (e.g.
+`GitLabPersonalAccessToken`) will rotate the bootstrap credential in place,
+so after first install there is no long-lived static credential to manage.
+
+!!! info "Planned"
+    Not yet implemented. See
+    [Resolutions to open questions §4](../design/open-questions-resolutions.md#4-operator-credential-management-self-referential-crds).
+
+## Invariant to remember
+
+After the operator adopts a Secret, it writes `/data/<keyName>` on every
+rotation. Whatever produces the bootstrap value must not fight the operator
+over that field — see [ArgoCD integration](argocd-integration.md) for the
+canonical example.

--- a/docs/guides/eso-pushsecret-composition.md
+++ b/docs/guides/eso-pushsecret-composition.md
@@ -1,0 +1,72 @@
+# ESO PushSecret composition
+
+The operator only exports rotated tokens to Kubernetes `Secret`s. For
+anything else — external vaults, webhook endpoints, multi-cluster sync — the
+supported pattern is [External Secrets Operator `PushSecret`](https://external-secrets.io/latest/api/pushsecret/),
+which references the Secret the operator writes and pushes it to any
+configured `SecretStore`.
+
+## Push to an external vault
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: PushSecret
+metadata:
+  name: gitlab-ci-token-to-vault
+spec:
+  selector:
+    secret:
+      name: gitlab-ci-token       # the Secret our operator writes
+  secretStoreRefs:
+    - name: vault
+      kind: ClusterSecretStore
+  data:
+    - match:
+        secretKey: token
+        remoteRef:
+          remoteKey: secret/gitlab/ci-token
+```
+
+## Push to a webhook
+
+ESO has a webhook provider. Configure a `SecretStore` with `provider:
+webhook`, point a `PushSecret` at it, and ESO POSTs the secret value on
+change.
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: rotation-webhook
+spec:
+  provider:
+    webhook:
+      url: "https://my-endpoint.example.com/rotated"
+      method: POST
+      headers:
+        Content-Type: application/json
+      body: |
+        {"token": "{{ .token }}"}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: PushSecret
+metadata:
+  name: gitlab-ci-token-webhook
+spec:
+  selector:
+    secret:
+      name: gitlab-ci-token
+  secretStoreRefs:
+    - name: rotation-webhook
+  data:
+    - match:
+        secretKey: token
+        remoteRef:
+          remoteKey: token
+```
+
+## Why not a native webhook field on the CR?
+
+ESO's webhook provider solves the problem — auth, TLS, body templating,
+retries — better than we would. See [Resolutions to open questions
+§3](../design/open-questions-resolutions.md#3-export-targets).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,16 @@
+# Guides
+
+Task-oriented walkthroughs for common integration patterns.
+
+- **[Bootstrap credentials](bootstrap-credentials.md)** — manual, GitOps, and
+  ESO paths for getting the operator's initial API credential into the
+  cluster.
+- **[ArgoCD integration](argocd-integration.md)** — how to stop ArgoCD from
+  fighting the operator over rotated Secret values.
+- **[Pod reload with Reloader](pod-reload-with-reloader.md)** — restart
+  consumer Pods automatically when a rotated Secret changes.
+- **[ESO PushSecret composition](eso-pushsecret-composition.md)** — deliver
+  rotated tokens to external stores or webhook endpoints via
+  external-secrets.
+- **[Observability](observability.md)** — Kubernetes Events, Prometheus
+  metrics, and OTLP export.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,49 @@
+# Observability
+
+The operator exposes three observability surfaces:
+
+- **Kubernetes Events** on each CR for every rotation lifecycle transition.
+- **Prometheus-compatible metrics** on the controller-runtime metrics
+  endpoint.
+- **OTLP metrics export**, configurable via environment variables for users
+  on OpenTelemetry-native stacks.
+
+Metrics are instrumented via the OpenTelemetry SDK and exported through
+*both* a Prometheus exporter (scrape endpoint) and optionally OTLP (push).
+
+!!! info "Planned"
+    Metric names and event reasons below are the committed design; the
+    implementation is in progress. See [Resolutions to open questions
+    §1](../design/open-questions-resolutions.md#1-failure-handling-observability-surface).
+
+## Events
+
+Emitted on the CR object. Discover with:
+
+```sh
+kubectl describe <kind> <name>
+kubectl get events --field-selector involvedObject.name=<name>
+```
+
+See [Reference › Events](../reference/events.md) for the full list.
+
+## Prometheus metrics
+
+Scrape the controller's `/metrics` endpoint. See [Reference ›
+Metrics](../reference/metrics.md) for metric names, labels, and semantics.
+
+Example Alertmanager rule — rotation hasn't succeeded in more than twice the
+rotation interval:
+
+```yaml
+- alert: TokenRotationStalled
+  expr: |
+    time() - token_rotator_last_success_timestamp_seconds
+      > on(kind,namespace,name) 2 * token_rotator_rotation_interval_seconds
+  for: 5m
+```
+
+## OTLP export
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` (and related OTel env vars) on the manager
+Deployment to enable OTLP metrics push. Disabled by default.

--- a/docs/guides/pod-reload-with-reloader.md
+++ b/docs/guides/pod-reload-with-reloader.md
@@ -1,0 +1,51 @@
+# Pod reload with Reloader
+
+The operator's contract ends at "Secret contains current value." How
+consumers pick up the new value is up to them.
+
+Kubelet refreshes mounted Secrets automatically (with some delay), but env-var
+Secrets and in-memory caches don't. [Stakater
+Reloader](https://github.com/stakater/Reloader) watches Secret changes and
+triggers rolling restarts of Deployments/StatefulSets/DaemonSets that reference
+them.
+
+## Annotation on the consumer
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  annotations:
+    secret.reloader.stakater.com/reload: "gitlab-ci-token"
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          envFrom:
+            - secretRef:
+                name: gitlab-ci-token
+```
+
+When the operator rotates `gitlab-ci-token`, Reloader triggers a rolling
+restart of `my-app`.
+
+## Pairing with `KeepOld`
+
+If consumer restart is slow (large images, long readiness probes), use the
+`KeepOld` rotation strategy with a grace period long enough to cover the
+restart:
+
+```yaml
+spec:
+  rotationStrategy:
+    type: KeepOld
+    keepOld:
+      gracePeriod: 1h
+```
+
+The previous token stays valid for `gracePeriod`, which bounds the window
+where a pod on the old Secret is briefly running alongside pods on the new
+Secret. See [Resolutions to open questions
+§2](../design/open-questions-resolutions.md#2-keepold-grace-period).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# Token Rotator
+
+A Kubernetes operator that rotates API tokens for third-party services, modeled
+on cert-manager. Each token source (GitLab, Tailscale, Docker Registry, DataDog,
+ArgoCD, Google Workspace, …) gets its own strongly-typed CRD, and the operator
+mints replacement tokens on a cron schedule or on demand, publishing them to a
+Kubernetes Secret.
+
+!!! warning "Work in progress"
+    This project is under active development. APIs are `v1alpha1` and may
+    change. Contributions welcome.
+
+## Source status
+
+| Source | CRD kind | Status |
+|---|---|---|
+| GitLab — project access tokens | `GitLabProjectAccessToken` | Implemented (v1alpha1) |
+| GitLab — group access tokens | `GitLabGroupAccessToken` | Planned |
+| GitLab — personal access tokens | `GitLabPersonalAccessToken` | Planned |
+| Tailscale | `TailscaleAuthKey` | Planned |
+| Docker Hub | `DockerHubAccessToken` | Planned |
+| DataDog | `DatadogApplicationKey` | Planned |
+| ArgoCD | `ArgoCDProjectToken` | Planned |
+| Google Workspace | `GoogleServiceAccountKey` | Planned |
+
+## Where to go next
+
+- **[Getting Started](getting-started/index.md)** — install the operator and
+  rotate your first token.
+- **[Design](design/index.md)** — the architectural decisions behind the
+  project.
+- **[Sources](sources/index.md)** — per-source reference and examples.
+- **[Guides](guides/index.md)** — bootstrap patterns, ArgoCD integration,
+  Reloader, ESO composition, observability.
+- **[Reference](reference/index.md)** — CRD API, metrics, events.

--- a/docs/reference/crd-api.md
+++ b/docs/reference/crd-api.md
@@ -1,0 +1,15 @@
+# CRD API reference
+
+!!! info "To be auto-generated"
+    This page is a placeholder. A future task will generate per-CRD field
+    reference from the `api/v1alpha1/*_types.go` sources (e.g. via
+    [`crd-ref-docs`](https://github.com/elastic/crd-ref-docs) or
+    [`crdoc`](https://github.com/fybrik/crdoc)).
+
+Until then, see:
+
+- `api/v1alpha1/tokenbase_types.go` — shared spec/status embedded by every
+  source CRD.
+- `api/v1alpha1/gitlabprojectaccesstoken_types.go` — GitLab project access
+  token CRD.
+- `config/crd/bases/` — generated OpenAPI schemas consumed by `kubectl apply`.

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,0 +1,25 @@
+# Events
+
+!!! info "Planned"
+    Event reasons below are the committed design; implementation is in
+    progress.
+
+All events are emitted on the CR object — `kubectl describe <kind> <name>`
+shows them, and `kubectl get events --field-selector involvedObject.name=<name>`
+lists them in time order.
+
+| Reason | Type | When |
+|---|---|---|
+| `RotationStarted` | Normal | A rotation reconcile has begun. |
+| `RotationSucceeded` | Normal | New token minted and exported successfully. |
+| `RotationFailed` | Warning | Rotation failed; message contains a non-sensitive reason. |
+| `TokenRevoked` | Normal | A previous token has been revoked (end of `KeepOld` grace period, or `Immediate` replacement). |
+| `ExportUpdated` | Normal | The exported Secret's value has been updated. |
+| `TookOwnership` | Normal | The controller adopted a pre-existing Secret (self-rotate CRDs). |
+| `DependencyCycle` | Warning | Two or more operator-managed Secrets reference each other via `apiTokenSecretRef`. |
+| `SecretNotAdopted` | Warning | A self-rotate CRD references a pre-existing Secret without `adoptExistingSecret: true`. |
+| `InvalidGracePeriod` | Warning | `KeepOld.gracePeriod` is >= `rotationInterval`; would produce two valid tokens indefinitely. |
+
+## Never emitted
+
+Event messages never contain token values or API credentials.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,7 @@
+# Reference
+
+Machine-oriented reference material.
+
+- **[CRD API](crd-api.md)** — per-CRD field reference.
+- **[Metrics](metrics.md)** — metric names, labels, and semantics.
+- **[Events](events.md)** — event reasons and when they fire.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,0 +1,28 @@
+# Metrics
+
+!!! info "Planned"
+    Metric names below are the committed design; implementation is in
+    progress.
+
+All metrics are exported via the OpenTelemetry SDK to both a Prometheus
+exporter (controller-runtime's `/metrics` endpoint) and optionally OTLP.
+
+## Inventory
+
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `token_rotator_rotation_attempts_total` | counter | `kind, source, namespace, name, result` | Rotations attempted. `result` ∈ `success|failure`. |
+| `token_rotator_rotation_failures_total` | counter | `kind, source, namespace, name, reason` | Rotation failures, labelled by failure reason. |
+| `token_rotator_last_success_timestamp_seconds` | gauge (async) | `kind, source, namespace, name` | Unix seconds of last successful rotation. |
+| `token_rotator_token_expiry_timestamp_seconds` | gauge (async) | `kind, source, namespace, name` | Unix seconds when the current token expires. |
+
+## Cardinality
+
+Labels include per-CR identity (`namespace`, `name`). Follows the
+cert-manager convention. If you have thousands of CRs, keep this in mind
+when sizing Prometheus storage.
+
+## Never emitted
+
+Metric labels never contain token values or API credentials. If you find one,
+that's a bug — report it.

--- a/docs/sources/gitlab-project-access-token.md
+++ b/docs/sources/gitlab-project-access-token.md
@@ -1,0 +1,58 @@
+# GitLab project access token
+
+Rotates a GitLab [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html)
+on a cron schedule.
+
+**Kind:** `GitLabProjectAccessToken`
+**API group:** `token-rotator.org`
+**Versions:** `v1alpha1`
+**Status:** implemented.
+
+## API credential
+
+The CR references a Kubernetes Secret via `spec.apiTokenSecretRef`. That Secret
+must hold a GitLab token with permission to create and revoke project access
+tokens on the target project — typically a maintainer-or-higher personal
+access token, group access token, or a bootstrapping project access token.
+
+Required scopes: `api`.
+
+!!! tip "Rotating the bootstrap credential itself"
+    See [Guides › Bootstrap credentials](../guides/bootstrap-credentials.md).
+
+## Example
+
+```yaml
+apiVersion: token-rotator.org/v1alpha1
+kind: GitLabProjectAccessToken
+metadata:
+  name: ci-token
+spec:
+  project: mygroup/myproject
+  accessLevel: Maintainer
+  scopes: [api, read_registry]
+  rotationSchedule: "0 0 1 * *"    # monthly, midnight UTC
+  rotationStrategy: Immediate
+  apiTokenSecretRef:
+    name: gitlab-api-credentials
+    key: token
+  export:
+    type: Secret
+    name: gitlab-ci-token
+```
+
+## Status
+
+- `status.lastRotationTime` — when the last successful rotation completed.
+- `status.nextRotationTime` — when the next rotation will occur.
+- `status.currentTokenRef` — the Secret holding the current token value.
+- `status.conditions` — `Ready`, with reason/message on failure.
+
+## Gotchas
+
+- **Lifetime.** The minted token's expiry is set to `2 × rotationInterval`,
+  giving a missed reconcile a second chance before consumers break.
+- **Access level mapping.** `accessLevel: Maintainer` maps to GitLab's
+  integer `40`. See the GitLab API reference for the full mapping.
+- **Revocation is idempotent.** A 404 from GitLab on revoke is treated as
+  success (previously revoked or never existed).

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -1,0 +1,21 @@
+# Sources
+
+Each token source is a separate CRD under the `token-rotator.org` API group.
+
+| Source | CRD kind | Status | Docs |
+|---|---|---|---|
+| GitLab — project access tokens | `GitLabProjectAccessToken` | Implemented (v1alpha1) | [Reference](gitlab-project-access-token.md) |
+| GitLab — group access tokens | `GitLabGroupAccessToken` | Planned | — |
+| GitLab — personal access tokens | `GitLabPersonalAccessToken` | Planned | — |
+| Tailscale | `TailscaleAuthKey` | Planned | — |
+| Docker Hub | `DockerHubAccessToken` | Planned | — |
+| DataDog | `DatadogApplicationKey` | Planned | — |
+| ArgoCD | `ArgoCDProjectToken` | Planned | — |
+| Google Workspace | `GoogleServiceAccountKey` | Planned | — |
+
+Each source page covers:
+
+- The CR schema (spec/status fields).
+- Required scopes on the API credential.
+- A minimal example CR.
+- Source-specific gotchas (rate limits, revocation semantics, etc.).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,1 @@
+/* Reserved for future theme overrides. */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Token Rotator
 site_description: A Kubernetes operator that rotates API tokens for third-party services.
-site_url: https://devonwarren.github.io/token-rotator/
+site_url: https://token-rotator.com/
 repo_url: https://github.com/devonwarren/token-rotator
 repo_name: devonwarren/token-rotator
 edit_uri: edit/main/docs/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,102 @@
+site_name: Token Rotator
+site_description: A Kubernetes operator that rotates API tokens for third-party services.
+site_url: https://devonwarren.github.io/token-rotator/
+repo_url: https://github.com/devonwarren/token-rotator
+repo_name: devonwarren/token-rotator
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+    - search.share
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - getting-started/index.md
+      - Install: getting-started/install.md
+      - Deploy: getting-started/deploy.md
+      - Try it: getting-started/try-it.md
+      - Tear down: getting-started/tear-down.md
+  - Design:
+      - design/index.md
+      - One CRD per source: design/crd-per-source.md
+      - Naming: design/naming.md
+      - Aggregation: design/aggregation.md
+      - Shared spec and status: design/shared-spec.md
+      - Resolutions to open questions: design/open-questions-resolutions.md
+  - Sources:
+      - sources/index.md
+      - GitLab project access token: sources/gitlab-project-access-token.md
+  - Guides:
+      - guides/index.md
+      - Bootstrap credentials: guides/bootstrap-credentials.md
+      - ArgoCD integration: guides/argocd-integration.md
+      - Pod reload with Reloader: guides/pod-reload-with-reloader.md
+      - ESO PushSecret composition: guides/eso-pushsecret-composition.md
+      - Observability: guides/observability.md
+  - Reference:
+      - reference/index.md
+      - CRD API: reference/crd-api.md
+      - Metrics: reference/metrics.md
+      - Events: reference/events.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+pymdown-extensions==10.12


### PR DESCRIPTION
## Summary

- Adds a MkDocs + Material documentation site with a full nav scaffold (Home, Getting Started, Design, Sources, Guides, Reference).
- Publishes to GitHub Pages via a new SHA-pinned `docs.yml` workflow with path filters (builds on PR, deploys on push to `main`).
- Adds `##@ Documentation` Makefile targets (`docs-venv`, `docs-serve`, `docs-build --strict`) and a pinned `requirements-docs.txt`.
- Includes `docs/design/open-questions-resolutions.md` capturing the decisions made in the same session on failure handling, `KeepOld` grace period, export targets, and credential management.

Content is skeleton-level: each page is a short stub with the shape and links in place; full content will land as features do.

## Test plan

- [x] `make docs-build` passes with `--strict` (no broken internal links, all nav entries resolve).
- [ ] `make docs-serve` renders locally at `http://127.0.0.1:8000`; click through every nav entry.
- [ ] PR's `docs / build` job passes (build-only on PR, no deploy).
- [ ] After merge: `docs / deploy` job runs; enable GitHub Pages in repo settings with source = GitHub Actions (one-time); site resolves at `https://devonwarren.github.io/token-rotator/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)